### PR TITLE
FIX: Surface distance calculations

### DIFF
--- a/brainsmash/workbench/geo.py
+++ b/brainsmash/workbench/geo.py
@@ -238,7 +238,7 @@ def subcortex(fout, image_file=None, dlabel=None, verbose=True):
             for n in range(n_vert):
                 if verbose and n % 1000 == 0:
                     print('Running vertex {} of {}'.format(n, n_vert))
-                np.savetxt(dest, [func(n, coords)])
+                np.savetxt(dest, func(n, coords))
     # We can store the temporary n_vert x label matrix in memory; running this
     # is much faster than trying to read through the giant vertex-vertex
     # distance matrix file
@@ -590,4 +590,4 @@ def _get_parcel_distance(vertex, dist, labels=None):
                             labels=np.delete(labels, vertex),
                             index=np.unique(labels))
 
-    return dist.astype(np.float32)
+    return np.atleast_2d(dist).astype(np.float32)

--- a/brainsmash/workbench/geo.py
+++ b/brainsmash/workbench/geo.py
@@ -99,7 +99,7 @@ def cortex(surface, outfile, euclid=False, dlabel=None, medial=None,
             for n in range(n_vert):
                 if verbose and n % 1000 == 0:
                     print('Running vertex {} of {}'.format(n, n_vert))
-                np.savetxt(dest, [func(n, graph)])
+                np.savetxt(dest, func(n, graph))
     # we can store the temporary n_vert x label matrix in memory; running this
     # is much faster than trying to read through the giant vertex-vertex
     # distance matrix file
@@ -494,7 +494,7 @@ def _get_workbench_distance(vertex, surf, labels=None):
     dist : (N,) numpy.ndarray
         Distance of `vertex` to all other vertices in `graph` (or to all
         parcels in `labels`, if provided)
-    
+
     """
 
     distcmd = 'wb_command -surface-geodesic-distance {surf} {vertex} {out}'
@@ -526,11 +526,11 @@ def _get_graph_distance(vertex, graph, labels=None):
     dist : (N,) numpy.ndarray
         Distance of `vertex` to all other vertices in `graph` (or to all
         parcels in `labels`, if provided)
-    
+
     Notes
     -----
     Distances are computed using Dijkstra's algorithm.
-    
+
     """
 
     # this involves an up-cast to float64; will produce some numerical rounding
@@ -558,7 +558,7 @@ def _get_euclid_distance(vertex, coords, labels=None):
     dist : (N,) or (M,) np.ndarray
         Distance of `vertex` to all other vertices in `coords` (or to all
         unique parcels in `labels`, if provided)
-    
+
     """
     dist = np.squeeze(cdist(coords[[vertex]], coords))
     return _get_parcel_distance(vertex, dist, labels)
@@ -582,7 +582,7 @@ def _get_parcel_distance(vertex, dist, labels=None):
     -------
     dist : np.ndarray
         Distance from `vertex` to all vertices/parcels, cast to float32
-    
+
     """
 
     if labels is not None:

--- a/brainsmash/workbench/surf.py
+++ b/brainsmash/workbench/surf.py
@@ -17,56 +17,64 @@ def _get_edges(faces):
     -------
     edges : (F*3, 2) array_like
         All edges in `faces`
-    
+
     """
     faces = np.asarray(faces)
     edges = np.sort(faces[:, [0, 1, 1, 2, 2, 0]].reshape((-1, 2)), axis=1)
     return edges
 
 
-def get_direct_edges(faces):
+def get_direct_edges(vertices, faces):
     """
-    Gets (unique) direct edges in mesh described by `faces`.
+    Gets (unique) direct edges and weights in mesh describes by inputs.
 
     Parameters
     ----------
+    vertices : (N, 3) array_like
+        Coordinates of `vertices` comprising mesh with `faces`
     faces : (F, 3) array_like
-        Set of indices creating triangular faces of a mesh
+        Indices of `vertices` that compose triangular faces of mesh
 
     Returns
     -------
     edges : (E, 2) array_like
-        Direct edges (without duplicates) in `faces`
-    
+        Indices of `vertices` comprising direct edges (without duplicates)
+    weights : (E, 1) array_like
+        Distances between `edges`
+
     """
-    edges = _get_edges(faces)
-    return np.unique(edges, axis=0)
+    edges = np.unique(_get_edges(faces), axis=0)
+    weights = np.linalg.norm(np.diff(vertices[edges], axis=1), axis=-1)
+    return edges, weights.squeeze()
 
 
-def get_indirect_edges(faces):
+def get_indirect_edges(vertices, faces):
     """
-    Gets indirect edges in mesh described by `faces`.
+    Gets indirect edges and weights in mesh described by inputs.
 
     Indirect edges are between two vertices that participate in faces sharing
     an edge.
 
     Parameters
     ----------
-    faces : (N, 3) array_like
-        Set of indices creating triangular faces of a mesh
+    vertices : (N, 3) array_like
+        Coordinates of `vertices` comprising mesh with `faces`
+    faces : (F, 3) array_like
+        Indices of `vertices` that compose triangular faces of mesh
 
     Returns
     -------
     edges : (E, 2) array_like
-        Indirect edges (without duplicates) in `faces`
+        Indices of `vertices` comprising indirect edges (without duplicates)
+    weights : (E, 1) array_like
+        Distances between `edges` on surface
 
     References
     ----------
     https://github.com/mikedh/trimesh (MIT licensed)
-    
-    """
 
-    # first generate the list of edges for the provbided faces and the
+    """
+    # first generate the list of edges for the provided faces and the
     # index for which face the edge is from (which is just the index of the
     # face repeated thrice, since each face generates three direct edges)
     edges = _get_edges(faces)
@@ -107,7 +115,20 @@ def get_indirect_edges(faces):
         unshared[~row_ok, :] = False
         indirect_edges[row_ok, i] = face[unshared]
 
-    return indirect_edges
+    shared = np.sort(face[np.logical_not(unshared)].reshape(-1, 1, 2), axis=-1)
+    shared = np.repeat(shared, 2, axis=1)
+    triangles = np.concatenate((shared, indirect_edges[..., None]), axis=-1)
+    coords = vertices[triangles].transpose(2, 3, 0, 1)
+
+    num = np.sum((coords[0] - coords[1]) * (coords[2] - coords[1]),
+                 axis=0, keepdims=True)
+    denom = np.sum((coords[0] - coords[1]) ** 2, axis=0, keepdims=True)
+    feet = coords[1] - (num / denom) * (coords[1] - coords[0])
+    midpoints = (np.sum(feet.transpose(1, 2, 0), axis=1) / 2)[:, None]
+    norms = np.linalg.norm(vertices[indirect_edges] - midpoints, axis=-1)
+    weights = np.sum(norms, axis=-1)
+
+    return indirect_edges, weights
 
 
 def make_surf_graph(vertices, faces, mask=None):
@@ -127,29 +148,28 @@ def make_surf_graph(vertices, faces, mask=None):
     Returns
     -------
     graph : scipy.sparse.csr_matrix
-        Sparse matrix representing `surf`
-    
+        Sparse matrix representing graph of `vertices` and `faces`
+
     Raises
     ------
-    ValueError : inconsistent number of vertices in `mask` and `surf`
+    ValueError : inconsistent number of vertices in `mask` and `vertices`
     """
 
     if mask is not None and len(mask) != len(vertices):
         raise ValueError('Supplied `mask` array has different number of '
-                         'vertices than supplied `surf`.')
+                         'vertices than supplied `vertices`.')
 
     # get all (direct + indirect) edges from surface
-    edges = np.row_stack([
-        get_direct_edges(faces), get_indirect_edges(faces)])
+    direct_edges, direct_weights = get_direct_edges(vertices, faces)
+    indirect_edges, indirect_weights = get_indirect_edges(vertices, faces)
+    edges = np.row_stack((direct_edges, indirect_edges))
+    weights = np.hstack((direct_weights, indirect_weights))
 
     # remove edges that include a vertex in `mask`
     if mask is not None:
         idx, = np.where(mask)
-        edges = edges[~np.any(np.isin(edges, idx), axis=1)]
-
-    # make weights (Euclidean distances b/w vertices)
-    # TODO: fix so we don't underestimate weights for all indirect edges
-    weights = np.linalg.norm(np.diff(vertices[edges], axis=1), axis=-1)
+        mask = ~np.any(np.isin(edges, idx), axis=1)
+        edges, weights = edges[mask], weights[mask]
 
     # construct our graph on which to calculate shortest paths
     return sparse.csr_matrix((np.squeeze(weights), (edges[:, 0], edges[:, 1])),


### PR DESCRIPTION
Closes #7.

So the answer in this PR wasn't exactly what I originally had in mind in #7, but this makes it so that the vertex-vertex distance matrix generated by the Dijkstra's in-memory computation is _much_ closer to the one that is generated by Connectome Workbench!

I ran into one small issue testing it as a result of some of the changes in 76e9fb6; I think I fixed that (but now looking at that commit I think a few small bugs might still be lingering). So, I guess don't merge this quite yet—I'll take a second look at it tomorrow morning and try and make sure all the bugs are squashed as best I can.

In the interim, if you want to take a look at the changes to `brainsmash.workbench.surf` to confirm they "make sense" that would be great! We're finding the midpoint (`M`) between the feet (`F1` and `F2`) of each pair of triangles sharing an edge. We're then finding the distance between the non-shared vertex of each triangle in the pair and the calculated midpoint (`M`) and summing those distances to get the indirect edge weight. This ensures that the path calculated for the indirect edges is always on the surface (whereas the Euclidean distance formerly used would generally not be on the surface and thus categorically underestimated things).

Let me know if that makes sense!