### PR TITLE
FIX: Removes np.VisibleDeprecationWarning in {Base,Sampled}.__call__()

### DIFF
--- a/brainsmash/mapgen/base.py
+++ b/brainsmash/mapgen/base.py
@@ -138,7 +138,7 @@ class Base:
                 res[delta] = self.regress(smvar_perm, self._smvar)
 
             alphas, betas, residuals = np.array(
-                [res[d] for d in self._deltas]).T
+                [res[d] for d in self._deltas], dtype=float).T
 
             # Select best-fit model and regression parameters
             iopt = np.argmin(residuals)

--- a/brainsmash/mapgen/sampled.py
+++ b/brainsmash/mapgen/sampled.py
@@ -163,7 +163,7 @@ class Sampled:
                 res[d] = self.regress(smvar_perm, smvar)
 
             alphas, betas, residuals = np.array(
-                [res[d] for d in self._deltas]).T
+                [res[d] for d in self._deltas], dtype=float).T
 
             # Select best-fit model and regression parameters
             iopt = np.argmin(residuals)


### PR DESCRIPTION
As of numpy 1.19.0, a `np.VisibleDeprecationWarning` was being raised in last step of the `__call__()` method for both `Base` and`Sampled` classes when results for different deltas were stacked into a single array (since `betas` were always a len-1 array while the other values were floats, it counted as a "ragged nested sequence"). 

Specifying `dtype=float` removes the warning and keeps the original output.