### PR TITLE
REF: Adds (optional) parallelization to surrogate generation

### DIFF
--- a/brainsmash/mapgen/base.py
+++ b/brainsmash/mapgen/base.py
@@ -122,16 +122,17 @@ class Base:
 
         """
 
-        rs = self._rs.randint(4294967295 - n)  # max RandomState allowed
+        rs = self._rs.randint(np.iinfo(np.int32).max, size=n)
         surrs = np.row_stack(
             Parallel(self._n_jobs)(
-                delayed(self._call_method)(rs=rs + i) for i in range(n)
+                delayed(self._call_method)(rs=i) for i in rs
             )
         )
         return np.asarray(surrs.squeeze())
 
     def _call_method(self, rs=None):
         """ Subfunction used by .__call__() for parallelization purposes """
+
         # Reset RandomState so parallel jobs yield different results
         self._rs = check_random_state(rs)
 

--- a/brainsmash/mapgen/sampled.py
+++ b/brainsmash/mapgen/sampled.py
@@ -125,10 +125,10 @@ class Sampled:
 
         """
 
-        rs = self._rs.randint(4294967295 - n)  # max RandomState allowed
+        rs = self._rs.randint(np.iinfo(np.int32).max, size=n)
         surrs = np.row_stack(
             Parallel(self._n_jobs)(
-                delayed(self._call_method)(rs=rs + i) for i in range(n)
+                delayed(self._call_method)(rs=i) for i in rs
             )
         )
         return np.asarray(surrs.squeeze())

--- a/brainsmash/mapgen/sampled.py
+++ b/brainsmash/mapgen/sampled.py
@@ -8,6 +8,7 @@ from .kernels import check_kernel
 from sklearn.linear_model import LinearRegression
 from sklearn.utils.validation import check_random_state
 import numpy as np
+from joblib import Parallel, delayed
 
 __all__ = ['Sampled']
 
@@ -53,6 +54,8 @@ class Sampled:
         Print surrogate count each time new surrogate map created
     seed : None or int or np.random.RandomState instance (default None)
         Specify the seed for random number generation (or random state instance)
+    n_jobs : int (default 1)
+        Number of jobs to use for parallelizing creation of surrogate maps
 
     Notes
     -----
@@ -69,9 +72,10 @@ class Sampled:
 
     def __init__(self, x, D, index, ns=500, pv=70, nh=25, knn=1000, b=None,
                  deltas=np.arange(0.3, 1., 0.2), kernel='exp', resample=False,
-                 verbose=False, seed=None):
+                 verbose=False, seed=None, n_jobs=1):
 
         self._rs = check_random_state(seed)
+        self._n_jobs = n_jobs
 
         self._verbose = verbose
         self.x = x
@@ -120,77 +124,83 @@ class Sampled:
         surrogate maps' variogram fits.
 
         """
-        if self._verbose:
-            print("Generating {} maps...".format(n))
-        surrs = np.empty((n, self._nmap))
-        for i in range(n):  # generate random maps
-            if self._verbose:
-                print(i+1)
 
-            # Randomly permute map
-            x_perm = self.permute_map()
+        rs = self._rs.randint(4294967295 - n)  # max RandomState allowed
+        surrs = np.row_stack(
+            Parallel(self._n_jobs)(
+                delayed(self._call_method)(rs=rs + i) for i in range(n)
+            )
+        )
+        return np.asarray(surrs.squeeze())
 
-            # Randomly select subset of regions to use for variograms
-            idx = self.sample()
+    def _call_method(self, rs=None):
+        """ Subfunction used by .__call__() for parallelization purposes """
 
-            # Compute empirical variogram
-            v = self.compute_variogram(self._x, idx)
+        # Reset RandomState so parallel jobs yield different results
+        self._rs = check_random_state(rs)
 
-            # Variogram ordinates; use nearest neighbors because local effect
-            u = self._D[idx, :]
-            uidx = np.where(u < self._dmax)
+        # Randomly permute map
+        x_perm = self.permute_map()
 
-            # Smooth empirical variogram
-            smvar, u0 = self.smooth_variogram(u[uidx], v[uidx], return_h=True)
+        # Randomly select subset of regions to use for variograms
+        idx = self.sample()
 
-            res = dict.fromkeys(self._deltas)
+        # Compute empirical variogram
+        v = self.compute_variogram(self._x, idx)
 
-            for d in self._deltas:  # foreach neighborhood size
+        # Variogram ordinates; use nearest neighbors because local effect
+        u = self._D[idx, :]
+        uidx = np.where(u < self._dmax)
 
-                k = int(d * self._knn)
+        # Smooth empirical variogram
+        smvar, u0 = self.smooth_variogram(u[uidx], v[uidx], return_h=True)
 
-                # Smooth the permuted map using k nearest neighbors to
-                # reintroduce spatial autocorrelation
-                sm_xperm = self.smooth_map(x=x_perm, k=k)
+        res = dict.fromkeys(self._deltas)
 
-                # Calculate variogram values for the smoothed permuted map
-                vperm = self.compute_variogram(sm_xperm, idx)
+        for d in self._deltas:  # foreach neighborhood size
 
-                # Calculate smoothed variogram of the smoothed permuted map
-                smvar_perm = self.smooth_variogram(u[uidx], vperm[uidx])
+            k = int(d * self._knn)
 
-                # Fit linear regression btwn smoothed variograms
-                res[d] = self.regress(smvar_perm, smvar)
+            # Smooth the permuted map using k nearest neighbors to
+            # reintroduce spatial autocorrelation
+            sm_xperm = self.smooth_map(x=x_perm, k=k)
 
-            alphas, betas, residuals = np.array(
-                [res[d] for d in self._deltas], dtype=float).T
+            # Calculate variogram values for the smoothed permuted map
+            vperm = self.compute_variogram(sm_xperm, idx)
 
-            # Select best-fit model and regression parameters
-            iopt = np.argmin(residuals)
-            dopt = self._deltas[iopt]
-            self._dopt = dopt
-            kopt = int(dopt * self._knn)
-            aopt = alphas[iopt]
-            bopt = betas[iopt]
+            # Calculate smoothed variogram of the smoothed permuted map
+            smvar_perm = self.smooth_variogram(u[uidx], vperm[uidx])
 
-            # Transform and smooth permuted map using best-fit parameters
-            sm_xperm_best = self.smooth_map(x=x_perm, k=kopt)
-            surr = (np.sqrt(np.abs(bopt)) * sm_xperm_best +
-                    np.sqrt(np.abs(aopt)) * self._rs.randn(self._nmap))
-            surrs[i] = surr
+            # Fit linear regression btwn smoothed variograms
+            res[d] = self.regress(smvar_perm, smvar)
+
+        alphas, betas, residuals = np.array(
+            [res[d] for d in self._deltas], dtype=float).T
+
+        # Select best-fit model and regression parameters
+        iopt = np.argmin(residuals)
+        dopt = self._deltas[iopt]
+        self._dopt = dopt
+        kopt = int(dopt * self._knn)
+        aopt = alphas[iopt]
+        bopt = betas[iopt]
+
+        # Transform and smooth permuted map using best-fit parameters
+        sm_xperm_best = self.smooth_map(x=x_perm, k=kopt)
+        surr = (np.sqrt(np.abs(bopt)) * sm_xperm_best +
+                np.sqrt(np.abs(aopt)) * self._rs.randn(self._nmap))
 
         if self._resample:  # resample values from empirical map
             sorted_map = np.sort(self._x)
-            for i, surr in enumerate(surrs):
-                ii = np.argsort(surr)
-                np.put(surr, ii, sorted_map)
+            ii = np.argsort(surr)
+            np.put(surr, ii, sorted_map)
         else:
-            surrs = surrs - np.nanmean(surrs, axis=1)[:, np.newaxis]  # De-mean
+            surr = surr - np.nanmean(surr) # De-mean
 
         if self._ismasked:
             return np.ma.masked_array(
-                data=surrs, mask=np.isnan(surrs)).squeeze()
-        return surrs.squeeze()
+                data=surr, mask=np.isnan(surr)).squeeze()
+        return surr.squeeze()
 
     def compute_variogram(self, x, idx):
         """

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,10 @@ from setuptools import setup, find_packages
 with open("README.md", "r") as f:
     readme = f.read()
 
-requirements = ["numpy", "scikit-learn", "pandas", "scipy", "matplotlib", "nibabel"]
+requirements = [
+    "numpy", "scikit-learn", "pandas", "scipy", "matplotlib", "nibabel",
+    "joblib"
+]
 
 setup(
     name="brainsmash",


### PR DESCRIPTION
Closes #9.

:wave: hello again, and happy (?) December! I'm about to head into some _heavy_ `brainsmash` usage times and figured having parallelization up and running would be really helpful (hopefully not just for me!), so I'm here with a PR 😅 

This PR re-organizes the main `.__call__()` methods of both `brainsmash.mapgen.Base` and `brainsmash.mapgen.Sampled` such that they can now generate surrogates in parallel. Parallelization is controlled via an `n_jobs` parameter which can be provided to both classes (defaults to 1, i.e., serial generation of surrogates). This also required adding `joblib` as a hard dependency to the setup.py—though note that it was already being installed via `scikit-learn`.

The bulk of the original code for the `.__call__()` methods have been moved to sub-functions in each class (`~._call_method()`) and lightly modified to accommodate the fact that `joblib` needs a sub-function over which to parallelize. Because of this I had to do some funky stuff with random states to ensure that the generated surrogates were all different within a given requested batch. Let me know if you have alternative thoughts / ideas on improving that—I am more than happy to discuss + implement something else.

Finally, because it's somewhat related (and was pretty easy to do), I also changed `brainsmash.workbench.cortex` so that it has the same `n_jobs` parameter and, if provided a `dlabel` file, will parallelize computation of the parcel-parcel distance matrix. (Unfortunately, we can't do this for the vertex-vertex distance matrix since it must be serially written out to disk to avoid memory issues.)

Let me know if you have any thoughts / concerns on all this! (Apologies for the sizable amount of code changes and the very ugly git diffs 😬)