### PR TITLE
Adds batch surrogate generation

### DIFF
--- a/brainsmash/mapgen/base.py
+++ b/brainsmash/mapgen/base.py
@@ -1,9 +1,9 @@
 """
 Generate spatial autocorrelation-preserving surrogate maps.
 """
-from brainsmash.mapgen.kernels import check_kernel
-from brainsmash.utils.checks import check_map, check_distmat, check_deltas, check_pv
-from brainsmash.utils.dataio import dataio
+from .mapgen.kernels import check_kernel
+from ..utils.checks import check_map, check_distmat, check_deltas, check_pv
+from ..utils.dataio import dataio
 from sklearn.utils.validation import check_random_state
 import numpy as np
 from joblib import Parallel, delayed
@@ -178,9 +178,9 @@ class Base:
                 np.sqrt(np.abs(aopt)) * self._rs.randn(self._nmap, i))
 
         if self._resample:  # resample values from empirical map
-            sorted_map = np.sort(self._x)
-            ii = np.argsort(surr)
-            np.put(surr, ii, sorted_map)
+            sorted_map = np.sort(self._x)[:, None]
+            ii = np.argsort(surr, axis=0)
+            np.put_along_axis(surr, ii, sorted_map, axis=0)
         else:
             surr -= surr.mean(axis=0)  # De-mean
 

--- a/brainsmash/mapgen/base.py
+++ b/brainsmash/mapgen/base.py
@@ -4,7 +4,6 @@ Generate spatial autocorrelation-preserving surrogate maps.
 from brainsmash.mapgen.kernels import check_kernel
 from brainsmash.utils.checks import check_map, check_distmat, check_deltas, check_pv
 from brainsmash.utils.dataio import dataio
-from sklearn.linear_model import LinearRegression
 from sklearn.utils.validation import check_random_state
 import numpy as np
 from joblib import Parallel, delayed
@@ -94,10 +93,7 @@ class Base:
         utrunc = self._u[self._uidx]
         self._h = np.linspace(utrunc.min(), utrunc.max(), self._nh)
         self.b = b
-        self._smvar = self.compute_smooth_variogram(self._x[..., None])
-
-        # Linear regression model
-        self._lm = LinearRegression(fit_intercept=True)
+        self._smvar = self.compute_smooth_variogram(self._x)
 
     def __call__(self, n=1, batch_size=1):
         """
@@ -210,6 +206,9 @@ class Base:
             `return_h` is True)
 
         """
+        if x.ndim < 2:
+            x = x[..., None]
+
         diff_ij = x[self._triu[1][self._uidx]] - x[self._triu[0][self._uidx]]
         v = 0.5 * np.square(diff_ij)
         u = self._u[self._uidx]

--- a/brainsmash/mapgen/eval.py
+++ b/brainsmash/mapgen/eval.py
@@ -45,14 +45,12 @@ def base_fit(x, D, nsurr=100, **params):
     surrogate_maps = generator(n=nsurr)
 
     # Compute empirical variogram
-    v = generator.compute_variogram(x)
-    emp_var, u0 = generator.smooth_variogram(v, return_h=True)
+    emp_var, u0 = generator.compute_smooth_variogram(x, return_h=True)
 
     # Compute surrogate map variograms
     surr_var = np.empty((nsurr, generator.nh))
     for i in range(nsurr):
-        v_null = generator.compute_variogram(surrogate_maps[i])
-        surr_var[i] = generator.smooth_variogram(v_null, return_h=False)
+        surr_var[i] = generator.compute_smooth_variogram(surrogate_maps[i])
 
     # # Create plot for visual comparison
 


### PR DESCRIPTION
:wave: hello again! I'm here with the latest in my continued efforts to reduce the computational time of `brainsmash`. (Sorry in advance for what became a huge message here 😬)

## tl;dr

This PR adds the ability to generate multiple surrogates in a single computational step (primarily using `numpy` vectorization techniques), rather than serially as was being done before.

## Brief explanation

When working on adding the capacity to parallelize surrogate creation I realized that there should be a way (or, rather, I hoped there would be a way) to "vectorize" creation of the surrogates using some `numpy` trickery. I took a whack at implementing that (currently only for the `Base()` class, because it's the simpler of the two) and it seems to have paid off. The default implementation is still completely serial (i.e., no parallelization, as before, and no batching), but this can now be controlled via the `batch_size` parameter to the `.__call__()` method. I set a limit (of 500) because I found that increasing beyond that generally yielded computational _deficits_ (due to memory overhead, I think), but generally something in the range of 100-200 works _really_ well for reducing computation time (especially when paired with parallelization!).


## Notable changes to codebase

I had to change a few things in the actual computations to avoid (as much as possible) using for-loops and to try and reduce memory overhead. Notable changes:

1. I combined the `Base.compute_variogram` and `Base.smooth_variogram` functions because you never actually used the _full_ variogram—only the reduced version, sub-indexed by `Base()._uidx`. Combining the functions allows us to only use the desired aspects of the variogram and save a _lot_ on memory overhead (i.e., by never calculating the full pairwise different matrix!).
2. I modified the `Base.regress()` method to not use `sklearn`. Because you may (depending on `batch_size`) have multiple `x` (the surrogate maps) and one `y` (the original map) and want to calculate `y~x_i` (rather than a multiple regression of `y~x`), actually doing the math out was the most computationally-efficient method. Any other way would've required an extra for-loop.
3. The call to `Base.smooth_map()` uses an internal for-loop because otherwise memory use _explodes_; it just chooses which of the for-loops is smaller to try and save a little bit of computation time.
4. **Important**: I changed the permutation index generation to use `np.random.random_sample`, since `np.random.permutation` cannot generate column-wise permutations and would require a for-loop. This is a _backwards-incompatible change_ since surrogates generated now will be different (even with the same seed) than those generated before. I can change it back to a for-looped `np.random.permutation` if you'd like (it should only increase computation time by a few seconds)—just let me know.


So two for-loops remain inside the surrogate generation, both involving `Base.smooth_map()`. I haven't figured out a way to remove them for the time being, but performance still seems improved despite them:

## Checking performance

As a little performance check I generated 10,000 surrogates for a 500 node parcellation (left hemisphere of the Schaefer 1000Parcels7Networks parcellation) using (i) no parallelization and no batching, (ii) no parallelization and some batching, (iii) some parallelization and no batching, and (iv) some parallelization and some batching. I timed these and used `memory_profiler` to assess the maximum memory usage over the computation. Since it seems `brainsmash` was originally designed with limited computational power in mind, I tested this on the "worst" computer I had access to (a 13-inch 2019 Macbook with 8GB RAM and a 1.4GHz quad core Intel core i5). Results below:

Test case | `n_jobs` | `batch_size` | Time elapsed (s) | Max memory usage (MB)
:---: | :---: | :---: | :---: | :---:
i | 1 | 1 | 2814.7 | 232.8
ii | 1 | 200 | 238.1 | 1046.9
iii | -1 | 1 | 1007.8 | 140.5
iv | -1 | 200 | 82.8 | 176.1
v | 1 | n/a | 2442.0 | 244.2

(Note 1: `n_jobs=-1` on my computer corresponds to `n_jobs=8`)
(Note 2: Max memory usage may not work as expected for parallelization purposes :grimacing: but I'm not totally sure how to address that)
(Note 3: Times + memory are from a _single_ run of each test case, so are liable to vary quite a bit)
(Note 4: **Test case v** corresponds to using the current `master` branch of `brainsmash` which I ran just to be sure I didn't totally screw anything up. Differences from **Test case i** may stem from the fact that I was more heavily using my computer during that test 😅 ~I'm letting **Test case i** run again and will update it once it's done.~ Updated! No major change 🤷‍♂️)

## Next steps

Apologies (late apologies) for just forging ahead with this before opening an issue to discuss. I kind of started to tackle it as a "can I even do this?" sort of thing and didn't want to bother you with it before determining whether it was feasible. If you think this is a reasonable path I can keep working on making it more performant, and possibly do something similar for `Sampled()`—note, however, that I have _very_ little experience with `Sampled()` (and memory mapping) and worry that memory usage issues will be a lot more prevalent with it.

Let me know your thoughts!